### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "source": "https://github.com/SergioMadness/payonline/releases"
   },
   "require": {
-    "illuminate/support": ">=5.2",
+    "illuminate/support": "5.2.* || 5.3.* || 5.4.* || 5.5.*",
     "alcohol/iso4217": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.

Also having a dependency listed with `*` isn't a good practice. Composer will install a new major version of that dependency even though it can break your app. 